### PR TITLE
Fix for readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ VideoCore is a project inteded to be an audio and video manipulation and streami
 
 Create a `Podfile` with the contents
 ``` ruby
-platform: ios, '6.0'
+platform :ios, '6.0'
 pod 'VideoCore', '~> 0.1.6'
 ```
 Next, run `pod install` and open the `xcworkspace` file that is created.


### PR DESCRIPTION
the space should be before the ‘:’, or it will get error “unexpected
‘:’” when running pod install
