### PR TITLE
use videoZoomFactor in setupGraph()

### DIFF
--- a/api/iOS/VCSimpleSession.mm
+++ b/api/iOS/VCSimpleSession.mm
@@ -406,7 +406,7 @@ static const float kAudioRate = 44100;
         auto aspectTransform = std::make_shared<videocore::AspectTransform>(self.videoSize.width,self.videoSize.height,videocore::AspectTransform::kAspectFit);
         
         auto positionTransform = std::make_shared<videocore::PositionTransform>(self.videoSize.width/2, self.videoSize.height/2,
-                                                                                self.videoSize.width, self.videoSize.height,
+                                                                                self.videoSize.width * self.videoZoomFactor, self.videoSize.height * self.videoZoomFactor,
                                                                                 self.videoSize.width, self.videoSize.height
                                                                                 );
         


### PR DESCRIPTION
Currently, if a videoZoomFactor different from 1.0 is set before setupGraph() is executed, it is ignored. With the simple change included in this PR, it is correctly taken into account.
