### PR TITLE
version bump in Podfile and stop ignoring first "Connect" button click

### DIFF
--- a/sample/SampleBroadcaster/Podfile
+++ b/sample/SampleBroadcaster/Podfile
@@ -2,5 +2,5 @@ platform :ios, '6.0'
 
 # See: http://guides.cocoapods.org/making/making-a-cocoapod.html#release
 # Once the pod has been released, use a version number here instead of a path.
-pod 'VideoCore', '~>0.1.7'
+pod 'VideoCore', '~>0.1.8'
 #pod 'VideoCore', path: '../..'

--- a/sample/SampleBroadcaster/Podfile.lock
+++ b/sample/SampleBroadcaster/Podfile.lock
@@ -16,18 +16,18 @@ PODS:
   - boost/string_algorithms-includes (1.51.0)
   - glm (0.9.4.6)
   - UriParser-cpp (0.1.3)
-  - VideoCore (0.1.7.1):
+  - VideoCore (0.1.8.4):
     - boost (~> 1.51.0)
     - glm (~> 0.9.4.6)
     - UriParser-cpp (~> 0.1.3)
 
 DEPENDENCIES:
-  - VideoCore (~> 0.1.7)
+  - VideoCore (~> 0.1.8)
 
 SPEC CHECKSUMS:
   boost: 581038adda16d11045576013ad27e3eeeabc2d10
   glm: 840dd35fe3cc445935accf81ffd1384dad532ee7
   UriParser-cpp: e6df3fd87445ba4ab37a72acafb4f03bc39db524
-  VideoCore: d9f14d595b29b99a7a362a719ebc2495af53bde9
+  VideoCore: 94ccf800d8527f5252a7c70c696aa81c608f5943
 
 COCOAPODS: 0.33.1

--- a/sample/SampleBroadcaster/SampleBroadcaster.xcodeproj/project.pbxproj
+++ b/sample/SampleBroadcaster/SampleBroadcaster.xcodeproj/project.pbxproj
@@ -214,7 +214,7 @@
 				ORGANIZATIONNAME = videocore;
 				TargetAttributes = {
 					7265D5DB191994B80042DC3B = {
-						DevelopmentTeam = 486S5TJL4J;
+						DevelopmentTeam = G5RU2HL4SN;
 					};
 					7265D5FF191994B80042DC3B = {
 						TestTargetID = 7265D5DB191994B80042DC3B;

--- a/sample/SampleBroadcaster/SampleBroadcaster/ViewController.mm
+++ b/sample/SampleBroadcaster/SampleBroadcaster/ViewController.mm
@@ -62,9 +62,10 @@
 - (IBAction)btnConnectTouch:(id)sender {
     
     switch(_session.rtmpSessionState) {
+        case VCSessionStateNone:
+        case VCSessionStatePreviewStarted:
         case VCSessionStateEnded:
         case VCSessionStateError:
-        case VCSessionStateNone:
             [_session startRtmpSessionWithURL:@"rtmp://192.168.1.151/live" andStreamKey:@"myStream"];
             break;
         default:


### PR DESCRIPTION
Update to correct VideoCore Pod in Podfile.

In `btnConnectTouch`, when state is `VCSessionStatePreviewStarted`, we will start (fixes bug where first click on "Connect" button was ignored).
