### PR TITLE
Added a new initializer to VCSimpleSession 

### DIFF
--- a/api/iOS/VCSimpleSession.h
+++ b/api/iOS/VCSimpleSession.h
@@ -92,6 +92,13 @@ typedef NS_ENUM(NSInteger, VCCameraState)
            useInterfaceOrientation:(BOOL)useInterfaceOrientation;
 
 // -----------------------------------------------------------------------------
+- (instancetype) initWithVideoSize:(CGSize)videoSize
+                         frameRate:(int)fps
+                           bitrate:(int)bps
+           useInterfaceOrientation:(BOOL)useInterfaceOrientation
+                       cameraState:(VCCameraState) cameraState;
+
+// -----------------------------------------------------------------------------
 - (void) startRtmpSessionWithURL:(NSString*) rtmpUrl
                     andStreamKey:(NSString*) streamKey;
 

--- a/api/iOS/VCSimpleSession.mm
+++ b/api/iOS/VCSimpleSession.mm
@@ -353,7 +353,8 @@ namespace videocore { namespace simpleApi {
         [self initInternalWithVideoSize:videoSize
                               frameRate:fps
                                 bitrate:bps
-                useInterfaceOrientation:NO];
+                useInterfaceOrientation:NO
+         cameraState:VCCameraStateBack];
         
     }
     return self;
@@ -369,15 +370,37 @@ namespace videocore { namespace simpleApi {
         [self initInternalWithVideoSize:videoSize
                               frameRate:fps
                                 bitrate:bps
-                useInterfaceOrientation:useInterfaceOrientation];
+                useInterfaceOrientation:useInterfaceOrientation
+                            cameraState:VCCameraStateBack];
     }
     return self;
 }
+
+- (instancetype) initWithVideoSize:(CGSize)videoSize
+                         frameRate:(int)fps
+                           bitrate:(int)bps
+           useInterfaceOrientation:(BOOL)useInterfaceOrientation
+                       cameraState:(VCCameraState) cameraState
+{
+    if (( self = [super init] ))
+    {
+        [self initInternalWithVideoSize:videoSize
+                              frameRate:fps
+                                bitrate:bps
+                useInterfaceOrientation:useInterfaceOrientation
+                            cameraState:cameraState];
+    }
+    return self;
+}
+
+
+
 
 - (void) initInternalWithVideoSize:(CGSize)videoSize
                          frameRate:(int)fps
                            bitrate:(int)bps
            useInterfaceOrientation:(BOOL)useInterfaceOrientation
+                       cameraState:(VCCameraState) cameraState
 {
     self.bitrate = bps;
     self.videoSize = videoSize;
@@ -391,7 +414,7 @@ namespace videocore { namespace simpleApi {
     _previewView = [[VCPreviewView alloc] init];
     self.videoZoomFactor = 1.f;
     
-    _cameraState = VCCameraStateBack;
+    _cameraState = cameraState;
     _exposurePOI = _focusPOI = CGPointMake(0.5f, 0.5f);
     _continuousExposure = _continuousAutofocus = YES;
     
@@ -623,7 +646,7 @@ namespace videocore { namespace simpleApi {
                                                                                 self.videoSize.width, self.videoSize.height
                                                                                 );
 
-        std::dynamic_pointer_cast<videocore::iOS::CameraSource>(m_cameraSource)->setupCamera(self.fps,false,self.useInterfaceOrientation);
+        std::dynamic_pointer_cast<videocore::iOS::CameraSource>(m_cameraSource)->setupCamera(self.fps,(self.cameraState == VCCameraStateFront),self.useInterfaceOrientation);
 
         m_cameraSource->setContinuousAutofocus(true);
         m_cameraSource->setContinuousExposure(true);


### PR DESCRIPTION
This allows the user to choose which camera to use on startup. I need my app to start up using the front camera. This is now possible. The other initializer still default to Back Camera so as not to break backwards compatibility.

Signed-off-by: David Hilowitz dhilowitz@gmail.com
