### PR TITLE
Fix #50 connect failure.

### DIFF
--- a/rtmp/RTMPSession.cpp
+++ b/rtmp/RTMPSession.cpp
@@ -466,7 +466,7 @@ namespace videocore
     {
         RTMPChunk_0 metadata = {{0}};
         metadata.msg_stream_id = kControlChannelStreamId;
-        metadata.msg_type_id = RTMP_PT_INVOKE;
+        metadata.msg_type_id = RTMP_PT_NOTIFY;
         std::vector<uint8_t> buff;
         put_string(buff, "releaseStream");
         put_double(buff, ++m_numberOfInvokes);
@@ -482,7 +482,7 @@ namespace videocore
     {
         RTMPChunk_0 metadata = {{0}};
         metadata.msg_stream_id = kControlChannelStreamId;
-        metadata.msg_type_id = RTMP_PT_INVOKE;
+        metadata.msg_type_id = RTMP_PT_NOTIFY;
         std::vector<uint8_t> buff;
         put_string(buff, "FCPublish");
         put_double(buff, ++m_numberOfInvokes);


### PR DESCRIPTION
d8a2354: Add a buffer size check to fix the problem. I didn't test it for crtmpserver, i just test it for my own rtmpserver. PLS test it.

cf709d2: Replace message type in "releaseStream" and "FCPublic" from invoke to notify. Because we're sending packet on it own queue and streaming network receive events on its own queue, so the invokers might be invoked async here. Replace from invoke to notify, the server will not return data, so it's just a walk around way. This is just a quick way to solve this problem, not the way i recommend, but it works now, so i send this pull request to you.
