### PR TITLE
Added optional protocol method that is called when camera source is loaded

### DIFF
--- a/api/iOS/VCSimpleSession.h
+++ b/api/iOS/VCSimpleSession.h
@@ -52,7 +52,7 @@ typedef NS_ENUM(NSInteger, VCCameraState)
     VCCameraStateBack
 };
 
-@protocol VCSessionDelegate
+@protocol VCSessionDelegate <NSObject>
 @required
 - (void) connectionStatusChanged: (VCSessionState) sessionState;
 @optional

--- a/api/iOS/VCSimpleSession.mm
+++ b/api/iOS/VCSimpleSession.mm
@@ -658,7 +658,9 @@ namespace videocore { namespace simpleApi {
         m_positionTransform = positionTransform;
         
         // Inform delegate that camera source has been added
-        [_delegate didAddCameraSource:self];
+        if ([_delegate respondsToSelector:@selector(didAddCameraSource:)]) {
+            [_delegate didAddCameraSource:self];
+        }
     }
     {
         // Add mic source


### PR DESCRIPTION
This is a small commit related to issue #86 that I opened and subsequently closed. I added an optional protocol that is called when the camera source is loaded. This allows the developer to set initial camera settings by calling the VCSimpleSession methods after the camera is loaded from the delegate. 
