### PR TITLE
allow device / interface orientation changes to be ignored

### DIFF
--- a/api/iOS/VCSimpleSession.h
+++ b/api/iOS/VCSimpleSession.h
@@ -70,6 +70,7 @@ typedef NS_ENUM(NSInteger, VCCameraState)
 @property (nonatomic, assign) int               fps;            // Change will not take place until the next RTMP Session
 @property (nonatomic, assign, readonly) BOOL    useInterfaceOrientation;
 @property (nonatomic, assign) VCCameraState cameraState;
+@property (nonatomic, assign) BOOL          orientationLocked;
 @property (nonatomic, assign) BOOL          torch;
 @property (nonatomic, assign) float         videoZoomFactor;
 @property (nonatomic, assign) int           audioChannelCount;

--- a/api/iOS/VCSimpleSession.mm
+++ b/api/iOS/VCSimpleSession.mm
@@ -125,6 +125,7 @@ namespace videocore { namespace simpleApi {
 
     VCCameraState _cameraState;
     VCSessionState _rtmpSessionState;
+    BOOL   _orientationLocked;
     BOOL   _torch;
     
     BOOL _useAdaptiveBitrate;
@@ -145,6 +146,7 @@ namespace videocore { namespace simpleApi {
 @dynamic bitrate;
 @dynamic fps;
 @dynamic useInterfaceOrientation;
+@dynamic orientationLocked;
 @dynamic torch;
 @dynamic cameraState;
 @dynamic rtmpSessionState;
@@ -198,6 +200,17 @@ namespace videocore { namespace simpleApi {
 - (BOOL) useInterfaceOrientation
 {
     return _useInterfaceOrientation;
+}
+- (BOOL) orientationLocked
+{
+    return _orientationLocked;
+}
+- (void) setOrientationLocked:(BOOL)orientationLocked
+{
+    _orientationLocked = orientationLocked;
+    if(m_cameraSource) {
+        m_cameraSource->setOrientationLocked(orientationLocked);
+    }
 }
 - (BOOL) torch
 {
@@ -639,6 +652,7 @@ namespace videocore { namespace simpleApi {
     {
         // Add camera source
         m_cameraSource = std::make_shared<videocore::iOS::CameraSource>();
+        m_cameraSource->setOrientationLocked(self.orientationLocked);
         auto aspectTransform = std::make_shared<videocore::AspectTransform>(self.videoSize.width,self.videoSize.height,videocore::AspectTransform::kAspectFit);
 
         auto positionTransform = std::make_shared<videocore::PositionTransform>(self.videoSize.width/2, self.videoSize.height/2,

--- a/sources/iOS/CameraSource.h
+++ b/sources/iOS/CameraSource.h
@@ -107,6 +107,22 @@ namespace videocore { namespace iOS {
          *  Toggle the camera between front and back-facing cameras.
          */
         void toggleCamera();
+
+        /*!
+         * If the orientation is locked, we ignore device / interface
+         * orientation changes.
+         *
+         * \return `true` is returned if the orientation is locked
+         */
+        bool orientationLocked();
+        
+        /*!
+         * Lock the camera orientation so that device / interface
+         * orientation changes are ignored.
+         *
+         *  \param orientationLocked  Bool indicating whether to lock the orientation.
+         */
+        void setOrientationLocked(bool orientationLocked);
         
         /*!
          *  Attempt to turn the torch mode on or off.
@@ -168,6 +184,7 @@ namespace videocore { namespace iOS {
         bool m_usingDeprecatedMethods;
         bool m_torchOn;
         bool m_useInterfaceOrientation;
+        bool m_orientationLocked;
 
     };
     


### PR DESCRIPTION
In some cases, it may be desirable to lock the orientation of the camera source so that no transforms are executed upon receiving device or interface orientation changes. This PR adds that capability to `CameraSource` and `VCSession`.
