### PR TITLE
Adding Swift Example Project

### DIFF
--- a/sample/SampleBroadcaster-Swift/Podfile
+++ b/sample/SampleBroadcaster-Swift/Podfile
@@ -1,0 +1,8 @@
+platform :ios, '6.0'
+
+source 'https://github.com/CocoaPods/Specs.git'
+
+# See: http://guides.cocoapods.org/making/making-a-cocoapod.html#release
+# Once the pod has been released, use a version number here instead of a path.
+#pod 'VideoCore', '~>0.3.0.3'
+pod 'VideoCore', path: '../..'

--- a/sample/SampleBroadcaster-Swift/Podfile
+++ b/sample/SampleBroadcaster-Swift/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '6.0'
+platform :ios, '8.0'
 
 source 'https://github.com/CocoaPods/Specs.git'
 

--- a/sample/SampleBroadcaster-Swift/Podfile.lock
+++ b/sample/SampleBroadcaster-Swift/Podfile.lock
@@ -1,0 +1,37 @@
+PODS:
+  - boost (1.51.0):
+    - boost/graph-includes (= 1.51.0)
+    - boost/math-includes (= 1.51.0)
+    - boost/numeric-includes (= 1.51.0)
+    - boost/pointer_cast-includes (= 1.51.0)
+    - boost/preprocessor-includes (= 1.51.0)
+    - boost/shared_ptr-includes (= 1.51.0)
+    - boost/string_algorithms-includes (= 1.51.0)
+  - boost/graph-includes (1.51.0)
+  - boost/math-includes (1.51.0)
+  - boost/numeric-includes (1.51.0)
+  - boost/pointer_cast-includes (1.51.0)
+  - boost/preprocessor-includes (1.51.0)
+  - boost/shared_ptr-includes (1.51.0)
+  - boost/string_algorithms-includes (1.51.0)
+  - glm (0.9.4.6)
+  - UriParser-cpp (0.1.3)
+  - VideoCore (0.3.0.3):
+    - boost (~> 1.51.0)
+    - glm (~> 0.9.4.6)
+    - UriParser-cpp (~> 0.1.3)
+
+DEPENDENCIES:
+  - VideoCore (from `../..`)
+
+EXTERNAL SOURCES:
+  VideoCore:
+    :path: ../..
+
+SPEC CHECKSUMS:
+  boost: 6c5c8d8daef26ac83c1e1c00ad14de62b80161d7
+  glm: e22c8d9df10404059b19c2952f9fa44d9a9f3056
+  UriParser-cpp: cbbe00080ee432ec4833dca863a7fc83adc9b01a
+  VideoCore: 5da08d095ef4b49f8562f84764964654a7d2afd7
+
+COCOAPODS: 0.36.0

--- a/sample/SampleBroadcaster-Swift/Podfile.lock
+++ b/sample/SampleBroadcaster-Swift/Podfile.lock
@@ -26,7 +26,7 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   VideoCore:
-    :path: ../..
+    :path: "../.."
 
 SPEC CHECKSUMS:
   boost: 6c5c8d8daef26ac83c1e1c00ad14de62b80161d7
@@ -34,4 +34,4 @@ SPEC CHECKSUMS:
   UriParser-cpp: cbbe00080ee432ec4833dca863a7fc83adc9b01a
   VideoCore: 5da08d095ef4b49f8562f84764964654a7d2afd7
 
-COCOAPODS: 0.36.0
+COCOAPODS: 0.36.3

--- a/sample/SampleBroadcaster-Swift/SampleBroadcaster-Swift.xcodeproj/project.pbxproj
+++ b/sample/SampleBroadcaster-Swift/SampleBroadcaster-Swift.xcodeproj/project.pbxproj
@@ -1,0 +1,491 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		6C157D311AD9735A00C7FAD3 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C157D301AD9735A00C7FAD3 /* AppDelegate.swift */; };
+		6C157D331AD9735A00C7FAD3 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C157D321AD9735A00C7FAD3 /* ViewController.swift */; };
+		6C157D361AD9735A00C7FAD3 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6C157D341AD9735A00C7FAD3 /* Main.storyboard */; };
+		6C157D381AD9735A00C7FAD3 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6C157D371AD9735A00C7FAD3 /* Images.xcassets */; };
+		6C157D3B1AD9735A00C7FAD3 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6C157D391AD9735A00C7FAD3 /* LaunchScreen.xib */; };
+		6C157D471AD9735A00C7FAD3 /* SampleBroadcaster_SwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C157D461AD9735A00C7FAD3 /* SampleBroadcaster_SwiftTests.swift */; };
+		8B59A3127B38E02A4C90825C /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6058F074796307839B7AC41D /* libPods.a */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		6C157D411AD9735A00C7FAD3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 6C157D231AD9735A00C7FAD3 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6C157D2A1AD9735A00C7FAD3;
+			remoteInfo = "SampleBroadcaster-Swift";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		52BDC6247D214345603DA33E /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
+		6058F074796307839B7AC41D /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		6C157D2B1AD9735A00C7FAD3 /* SampleBroadcaster-Swift.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "SampleBroadcaster-Swift.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		6C157D2F1AD9735A00C7FAD3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		6C157D301AD9735A00C7FAD3 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		6C157D321AD9735A00C7FAD3 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		6C157D351AD9735A00C7FAD3 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		6C157D371AD9735A00C7FAD3 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
+		6C157D3A1AD9735A00C7FAD3 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
+		6C157D401AD9735A00C7FAD3 /* SampleBroadcaster-SwiftTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SampleBroadcaster-SwiftTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		6C157D451AD9735A00C7FAD3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		6C157D461AD9735A00C7FAD3 /* SampleBroadcaster_SwiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleBroadcaster_SwiftTests.swift; sourceTree = "<group>"; };
+		6C157D501AD9A24900C7FAD3 /* VideoCore-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "VideoCore-Bridging-Header.h"; sourceTree = "<group>"; };
+		95EC6354D0742E62CDCE2046 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		6C157D281AD9735A00C7FAD3 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8B59A3127B38E02A4C90825C /* libPods.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6C157D3D1AD9735A00C7FAD3 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		6C157D221AD9735A00C7FAD3 = {
+			isa = PBXGroup;
+			children = (
+				6C157D2D1AD9735A00C7FAD3 /* SampleBroadcaster-Swift */,
+				6C157D431AD9735A00C7FAD3 /* SampleBroadcaster-SwiftTests */,
+				6C157D2C1AD9735A00C7FAD3 /* Products */,
+				E38CCD7FBEF04752DE8CD164 /* Pods */,
+				7569E797EB7C5A42BF24521D /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		6C157D2C1AD9735A00C7FAD3 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				6C157D2B1AD9735A00C7FAD3 /* SampleBroadcaster-Swift.app */,
+				6C157D401AD9735A00C7FAD3 /* SampleBroadcaster-SwiftTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		6C157D2D1AD9735A00C7FAD3 /* SampleBroadcaster-Swift */ = {
+			isa = PBXGroup;
+			children = (
+				6C157D301AD9735A00C7FAD3 /* AppDelegate.swift */,
+				6C157D321AD9735A00C7FAD3 /* ViewController.swift */,
+				6C157D341AD9735A00C7FAD3 /* Main.storyboard */,
+				6C157D371AD9735A00C7FAD3 /* Images.xcassets */,
+				6C157D391AD9735A00C7FAD3 /* LaunchScreen.xib */,
+				6C157D2E1AD9735A00C7FAD3 /* Supporting Files */,
+				6C157D501AD9A24900C7FAD3 /* VideoCore-Bridging-Header.h */,
+			);
+			path = "SampleBroadcaster-Swift";
+			sourceTree = "<group>";
+		};
+		6C157D2E1AD9735A00C7FAD3 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				6C157D2F1AD9735A00C7FAD3 /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		6C157D431AD9735A00C7FAD3 /* SampleBroadcaster-SwiftTests */ = {
+			isa = PBXGroup;
+			children = (
+				6C157D461AD9735A00C7FAD3 /* SampleBroadcaster_SwiftTests.swift */,
+				6C157D441AD9735A00C7FAD3 /* Supporting Files */,
+			);
+			path = "SampleBroadcaster-SwiftTests";
+			sourceTree = "<group>";
+		};
+		6C157D441AD9735A00C7FAD3 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				6C157D451AD9735A00C7FAD3 /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		7569E797EB7C5A42BF24521D /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				6058F074796307839B7AC41D /* libPods.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		E38CCD7FBEF04752DE8CD164 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				95EC6354D0742E62CDCE2046 /* Pods.debug.xcconfig */,
+				52BDC6247D214345603DA33E /* Pods.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		6C157D2A1AD9735A00C7FAD3 /* SampleBroadcaster-Swift */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6C157D4A1AD9735A00C7FAD3 /* Build configuration list for PBXNativeTarget "SampleBroadcaster-Swift" */;
+			buildPhases = (
+				AA44F1B90D087CE6F3B65E6F /* Check Pods Manifest.lock */,
+				6C157D271AD9735A00C7FAD3 /* Sources */,
+				6C157D281AD9735A00C7FAD3 /* Frameworks */,
+				6C157D291AD9735A00C7FAD3 /* Resources */,
+				FDBE69581D94F3988CD5CE27 /* Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "SampleBroadcaster-Swift";
+			productName = "SampleBroadcaster-Swift";
+			productReference = 6C157D2B1AD9735A00C7FAD3 /* SampleBroadcaster-Swift.app */;
+			productType = "com.apple.product-type.application";
+		};
+		6C157D3F1AD9735A00C7FAD3 /* SampleBroadcaster-SwiftTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6C157D4D1AD9735A00C7FAD3 /* Build configuration list for PBXNativeTarget "SampleBroadcaster-SwiftTests" */;
+			buildPhases = (
+				6C157D3C1AD9735A00C7FAD3 /* Sources */,
+				6C157D3D1AD9735A00C7FAD3 /* Frameworks */,
+				6C157D3E1AD9735A00C7FAD3 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				6C157D421AD9735A00C7FAD3 /* PBXTargetDependency */,
+			);
+			name = "SampleBroadcaster-SwiftTests";
+			productName = "SampleBroadcaster-SwiftTests";
+			productReference = 6C157D401AD9735A00C7FAD3 /* SampleBroadcaster-SwiftTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		6C157D231AD9735A00C7FAD3 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0630;
+				ORGANIZATIONNAME = videocore;
+				TargetAttributes = {
+					6C157D2A1AD9735A00C7FAD3 = {
+						CreatedOnToolsVersion = 6.3;
+					};
+					6C157D3F1AD9735A00C7FAD3 = {
+						CreatedOnToolsVersion = 6.3;
+						TestTargetID = 6C157D2A1AD9735A00C7FAD3;
+					};
+				};
+			};
+			buildConfigurationList = 6C157D261AD9735A00C7FAD3 /* Build configuration list for PBXProject "SampleBroadcaster-Swift" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 6C157D221AD9735A00C7FAD3;
+			productRefGroup = 6C157D2C1AD9735A00C7FAD3 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				6C157D2A1AD9735A00C7FAD3 /* SampleBroadcaster-Swift */,
+				6C157D3F1AD9735A00C7FAD3 /* SampleBroadcaster-SwiftTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		6C157D291AD9735A00C7FAD3 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6C157D361AD9735A00C7FAD3 /* Main.storyboard in Resources */,
+				6C157D3B1AD9735A00C7FAD3 /* LaunchScreen.xib in Resources */,
+				6C157D381AD9735A00C7FAD3 /* Images.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6C157D3E1AD9735A00C7FAD3 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		AA44F1B90D087CE6F3B65E6F /* Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		FDBE69581D94F3988CD5CE27 /* Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		6C157D271AD9735A00C7FAD3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6C157D331AD9735A00C7FAD3 /* ViewController.swift in Sources */,
+				6C157D311AD9735A00C7FAD3 /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6C157D3C1AD9735A00C7FAD3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6C157D471AD9735A00C7FAD3 /* SampleBroadcaster_SwiftTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		6C157D421AD9735A00C7FAD3 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 6C157D2A1AD9735A00C7FAD3 /* SampleBroadcaster-Swift */;
+			targetProxy = 6C157D411AD9735A00C7FAD3 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		6C157D341AD9735A00C7FAD3 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				6C157D351AD9735A00C7FAD3 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		6C157D391AD9735A00C7FAD3 /* LaunchScreen.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				6C157D3A1AD9735A00C7FAD3 /* Base */,
+			);
+			name = LaunchScreen.xib;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		6C157D481AD9735A00C7FAD3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		6C157D491AD9735A00C7FAD3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		6C157D4B1AD9735A00C7FAD3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 95EC6354D0742E62CDCE2046 /* Pods.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				INFOPLIST_FILE = "SampleBroadcaster-Swift/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "SampleBroadcaster-Swift/VideoCore-Bridging-Header.h";
+			};
+			name = Debug;
+		};
+		6C157D4C1AD9735A00C7FAD3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 52BDC6247D214345603DA33E /* Pods.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				INFOPLIST_FILE = "SampleBroadcaster-Swift/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "SampleBroadcaster-Swift/VideoCore-Bridging-Header.h";
+			};
+			name = Release;
+		};
+		6C157D4E1AD9735A00C7FAD3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = "SampleBroadcaster-SwiftTests/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SampleBroadcaster-Swift.app/SampleBroadcaster-Swift";
+			};
+			name = Debug;
+		};
+		6C157D4F1AD9735A00C7FAD3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = "SampleBroadcaster-SwiftTests/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SampleBroadcaster-Swift.app/SampleBroadcaster-Swift";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		6C157D261AD9735A00C7FAD3 /* Build configuration list for PBXProject "SampleBroadcaster-Swift" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6C157D481AD9735A00C7FAD3 /* Debug */,
+				6C157D491AD9735A00C7FAD3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		6C157D4A1AD9735A00C7FAD3 /* Build configuration list for PBXNativeTarget "SampleBroadcaster-Swift" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6C157D4B1AD9735A00C7FAD3 /* Debug */,
+				6C157D4C1AD9735A00C7FAD3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		6C157D4D1AD9735A00C7FAD3 /* Build configuration list for PBXNativeTarget "SampleBroadcaster-SwiftTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6C157D4E1AD9735A00C7FAD3 /* Debug */,
+				6C157D4F1AD9735A00C7FAD3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 6C157D231AD9735A00C7FAD3 /* Project object */;
+}

--- a/sample/SampleBroadcaster-Swift/SampleBroadcaster-Swift.xcodeproj/project.pbxproj
+++ b/sample/SampleBroadcaster-Swift/SampleBroadcaster-Swift.xcodeproj/project.pbxproj
@@ -403,6 +403,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = "SampleBroadcaster-Swift/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "SampleBroadcaster-Swift/VideoCore-Bridging-Header.h";
@@ -415,6 +416,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = "SampleBroadcaster-Swift/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "SampleBroadcaster-Swift/VideoCore-Bridging-Header.h";

--- a/sample/SampleBroadcaster-Swift/SampleBroadcaster-Swift/AppDelegate.swift
+++ b/sample/SampleBroadcaster-Swift/SampleBroadcaster-Swift/AppDelegate.swift
@@ -1,0 +1,46 @@
+//
+//  AppDelegate.swift
+//  SampleBroadcaster-Swift
+//
+//  Created by Josh Lieberman on 4/11/15.
+//  Copyright (c) 2015 videocore. All rights reserved.
+//
+
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    var window: UIWindow?
+
+
+    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    func applicationWillResignActive(application: UIApplication) {
+        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+        // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
+    }
+
+    func applicationDidEnterBackground(application: UIApplication) {
+        // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
+        // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+    }
+
+    func applicationWillEnterForeground(application: UIApplication) {
+        // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
+    }
+
+    func applicationDidBecomeActive(application: UIApplication) {
+        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+    }
+
+    func applicationWillTerminate(application: UIApplication) {
+        // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+    }
+
+
+}
+

--- a/sample/SampleBroadcaster-Swift/SampleBroadcaster-Swift/Base.lproj/LaunchScreen.xib
+++ b/sample/SampleBroadcaster-Swift/SampleBroadcaster-Swift/Base.lproj/LaunchScreen.xib
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6214" systemVersion="14A314h" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6207"/>
+        <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="480"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  Copyright (c) 2015 videocore. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="8ie-xW-0ye">
+                    <rect key="frame" x="20" y="439" width="441" height="21"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SampleBroadcaster-Swift" textAlignment="center" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" minimumFontSize="18" translatesAutoresizingMaskIntoConstraints="NO" id="kId-c2-rCX">
+                    <rect key="frame" x="20" y="140" width="441" height="43"/>
+                    <fontDescription key="fontDescription" type="boldSystem" pointSize="36"/>
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <constraints>
+                <constraint firstItem="kId-c2-rCX" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="bottom" multiplier="1/3" constant="1" id="5cJ-9S-tgC"/>
+                <constraint firstAttribute="centerX" secondItem="kId-c2-rCX" secondAttribute="centerX" id="Koa-jz-hwk"/>
+                <constraint firstAttribute="bottom" secondItem="8ie-xW-0ye" secondAttribute="bottom" constant="20" id="Kzo-t9-V3l"/>
+                <constraint firstItem="8ie-xW-0ye" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="20" symbolic="YES" id="MfP-vx-nX0"/>
+                <constraint firstAttribute="centerX" secondItem="8ie-xW-0ye" secondAttribute="centerX" id="ZEH-qu-HZ9"/>
+                <constraint firstItem="kId-c2-rCX" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="20" symbolic="YES" id="fvb-Df-36g"/>
+            </constraints>
+            <nil key="simulatedStatusBarMetrics"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <point key="canvasLocation" x="548" y="455"/>
+        </view>
+    </objects>
+</document>

--- a/sample/SampleBroadcaster-Swift/SampleBroadcaster-Swift/Base.lproj/Main.storyboard
+++ b/sample/SampleBroadcaster-Swift/SampleBroadcaster-Swift/Base.lproj/Main.storyboard
@@ -28,6 +28,9 @@
                                 <state key="normal" title="Connect">
                                     <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
+                                <connections>
+                                    <action selector="btnConnectTouch:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="lvs-Ku-gNe"/>
+                                </connections>
                             </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
@@ -42,6 +45,10 @@
                         </constraints>
                     </view>
                     <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>
+                    <connections>
+                        <outlet property="btnConnect" destination="LtG-lf-Rbt" id="pDg-sl-tIh"/>
+                        <outlet property="previewView" destination="l9C-zN-svY" id="HH2-bj-chh"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="x5A-6p-PRh" sceneMemberID="firstResponder"/>
             </objects>

--- a/sample/SampleBroadcaster-Swift/SampleBroadcaster-Swift/Base.lproj/Main.storyboard
+++ b/sample/SampleBroadcaster-Swift/SampleBroadcaster-Swift/Base.lproj/Main.storyboard
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7531" systemVersion="14D131" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="vXZ-lx-hvc">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7520"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="ufC-wZ-h7g">
+            <objects>
+                <viewController id="vXZ-lx-hvc" customClass="ViewController" customModule="SampleBroadcaster_Swift" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="jyV-Pf-zRb"/>
+                        <viewControllerLayoutGuide type="bottom" id="2fi-mo-0CV"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="kh9-bI-dsS">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="l9C-zN-svY">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="580"/>
+                            </view>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LtG-lf-Rbt">
+                                <rect key="frame" x="117" y="612" width="140" height="35"/>
+                                <color key="backgroundColor" white="0.39000000000000001" alpha="1" colorSpace="calibratedWhite"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="140" id="W2M-lz-wMm"/>
+                                </constraints>
+                                <state key="normal" title="Connect">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstAttribute="bottom" secondItem="LtG-lf-Rbt" secondAttribute="bottom" constant="20" symbolic="YES" id="1G1-4I-AkI"/>
+                            <constraint firstItem="LtG-lf-Rbt" firstAttribute="top" secondItem="l9C-zN-svY" secondAttribute="bottom" constant="32" id="64h-a4-6mk"/>
+                            <constraint firstAttribute="trailing" secondItem="l9C-zN-svY" secondAttribute="trailing" id="ANy-Mm-pTj"/>
+                            <constraint firstAttribute="bottom" secondItem="l9C-zN-svY" secondAttribute="bottom" constant="87" id="ahb-Ud-0uJ"/>
+                            <constraint firstItem="LtG-lf-Rbt" firstAttribute="centerX" secondItem="l9C-zN-svY" secondAttribute="centerX" id="cX4-Ve-mFQ"/>
+                            <constraint firstItem="l9C-zN-svY" firstAttribute="leading" secondItem="kh9-bI-dsS" secondAttribute="leading" id="n4J-V6-gBA"/>
+                            <constraint firstItem="l9C-zN-svY" firstAttribute="top" secondItem="kh9-bI-dsS" secondAttribute="top" id="w5m-YH-LLu"/>
+                        </constraints>
+                    </view>
+                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="x5A-6p-PRh" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="304.5" y="365.5"/>
+        </scene>
+    </scenes>
+</document>

--- a/sample/SampleBroadcaster-Swift/SampleBroadcaster-Swift/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/sample/SampleBroadcaster-Swift/SampleBroadcaster-Swift/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/sample/SampleBroadcaster-Swift/SampleBroadcaster-Swift/Info.plist
+++ b/sample/SampleBroadcaster-Swift/SampleBroadcaster-Swift/Info.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>videocore.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/sample/SampleBroadcaster-Swift/SampleBroadcaster-Swift/VideoCore-Bridging-Header.h
+++ b/sample/SampleBroadcaster-Swift/SampleBroadcaster-Swift/VideoCore-Bridging-Header.h
@@ -1,0 +1,14 @@
+//
+//  VideoCore-Bridging-Header.h
+//  SampleBroadcaster-Swift
+//
+//  Created by Josh Lieberman on 4/11/15.
+//  Copyright (c) 2015 videocore. All rights reserved.
+//
+
+#ifndef SampleBroadcaster_Swift_VideoCore_Bridging_Header_h
+#define SampleBroadcaster_Swift_VideoCore_Bridging_Header_h
+
+#import "VCSimpleSession.h"
+
+#endif

--- a/sample/SampleBroadcaster-Swift/SampleBroadcaster-Swift/ViewController.swift
+++ b/sample/SampleBroadcaster-Swift/SampleBroadcaster-Swift/ViewController.swift
@@ -1,0 +1,25 @@
+//
+//  ViewController.swift
+//  SampleBroadcaster-Swift
+//
+//  Created by Josh Lieberman on 4/11/15.
+//  Copyright (c) 2015 videocore. All rights reserved.
+//
+
+import UIKit
+
+class ViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do any additional setup after loading the view, typically from a nib.
+    }
+
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+        // Dispose of any resources that can be recreated.
+    }
+
+
+}
+

--- a/sample/SampleBroadcaster-Swift/SampleBroadcaster-Swift/ViewController.swift
+++ b/sample/SampleBroadcaster-Swift/SampleBroadcaster-Swift/ViewController.swift
@@ -8,18 +8,56 @@
 
 import UIKit
 
-class ViewController: UIViewController {
+class ViewController: UIViewController, VCSessionDelegate
+{
 
+    @IBOutlet weak var previewView: UIView!
+    @IBOutlet weak var btnConnect: UIButton!
+    
+    var session:VCSimpleSession = VCSimpleSession(videoSize: CGSize(width: 1280, height: 720), frameRate: 30, bitrate: 1000000, useInterfaceOrientation: false)
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view, typically from a nib.
+        
+        previewView.addSubview(session.previewView)
+        session.previewView.frame = previewView.bounds
+        session.delegate = self
+        
     }
 
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.
     }
+    
+    deinit {
+        btnConnect = nil
+        previewView = nil
+        session = nil
+    }
 
-
+    @IBAction func btnConnectTouch(sender: AnyObject) {
+        switch session.rtmpSessionState {
+        case .None, .PreviewStarted, .Ended, .Error:
+            session.startRtmpSessionWithURL("rtmp://192.168.1.151/live", andStreamKey: "myStream")
+        default:
+            session.endRtmpSession()
+            break
+        }
+    }
+    
+    func connectionStatusChanged(sessionState: VCSessionState) {
+        switch session.rtmpSessionState {
+        case .Starting:
+            btnConnect.setTitle("Connecting", forState: .Normal)
+            
+        case .Started:
+            btnConnect.setTitle("Disconnect", forState: .Normal)
+            
+        default:
+            btnConnect.setTitle("Connect", forState: .Normal)
+        }
+    }
 }
 

--- a/sample/SampleBroadcaster-Swift/SampleBroadcaster-Swift/ViewController.swift
+++ b/sample/SampleBroadcaster-Swift/SampleBroadcaster-Swift/ViewController.swift
@@ -34,7 +34,6 @@ class ViewController: UIViewController, VCSessionDelegate
     deinit {
         btnConnect = nil
         previewView = nil
-        session = nil
     }
 
     @IBAction func btnConnectTouch(sender: AnyObject) {

--- a/sample/SampleBroadcaster-Swift/SampleBroadcaster-SwiftTests/Info.plist
+++ b/sample/SampleBroadcaster-Swift/SampleBroadcaster-SwiftTests/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>videocore.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/sample/SampleBroadcaster-Swift/SampleBroadcaster-SwiftTests/SampleBroadcaster_SwiftTests.swift
+++ b/sample/SampleBroadcaster-Swift/SampleBroadcaster-SwiftTests/SampleBroadcaster_SwiftTests.swift
@@ -1,0 +1,36 @@
+//
+//  SampleBroadcaster_SwiftTests.swift
+//  SampleBroadcaster-SwiftTests
+//
+//  Created by Josh Lieberman on 4/11/15.
+//  Copyright (c) 2015 videocore. All rights reserved.
+//
+
+import UIKit
+import XCTest
+
+class SampleBroadcaster_SwiftTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    func testExample() {
+        // This is an example of a functional test case.
+        XCTAssert(true, "Pass")
+    }
+    
+    func testPerformanceExample() {
+        // This is an example of a performance test case.
+        self.measureBlock() {
+            // Put the code you want to measure the time of here.
+        }
+    }
+    
+}


### PR DESCRIPTION
This PR adds an example Swift project using `VCSimpleSession`.  This project attempts to match the Objective-C sample project as closely as possible, importing `VCSimpleSession.h` through a Bridging Header.  This was built using Xcode Version 6.3 (6D570) targeting the iOS 8.0 SDK.

I'm still studying Swift style best practices, so let me know if you want to make any modifications to the code style or formatting.