### PR TITLE
added a callback in CameraSource::setupCamera() to execute a block after...

### DIFF
--- a/api/iOS/VCSimpleSession.mm
+++ b/api/iOS/VCSimpleSession.mm
@@ -723,23 +723,24 @@ namespace videocore { namespace simpleApi {
                                                                                 self.videoSize.width, self.videoSize.height
                                                                                 );
 
-        std::dynamic_pointer_cast<videocore::iOS::CameraSource>(m_cameraSource)->setupCamera(self.fps,(self.cameraState == VCCameraStateFront),self.useInterfaceOrientation);
 
-        m_cameraSource->setContinuousAutofocus(true);
-        m_cameraSource->setContinuousExposure(true);
+        std::dynamic_pointer_cast<videocore::iOS::CameraSource>(m_cameraSource)->setupCamera(self.fps,(self.cameraState == VCCameraStateFront),self.useInterfaceOrientation,nil,^{
+            m_cameraSource->setContinuousAutofocus(true);
+            m_cameraSource->setContinuousExposure(true);
 
-        m_cameraSource->setOutput(aspectTransform);
+            m_cameraSource->setOutput(aspectTransform);
 
-        m_videoMixer->setSourceFilter(m_cameraSource, dynamic_cast<videocore::IVideoFilter*>(m_videoMixer->filterFactory().filter("com.videocore.filters.bgra")));
-        aspectTransform->setOutput(positionTransform);
-        positionTransform->setOutput(m_videoMixer);
-        m_aspectTransform = aspectTransform;
-        m_positionTransform = positionTransform;
+            m_videoMixer->setSourceFilter(m_cameraSource, dynamic_cast<videocore::IVideoFilter*>(m_videoMixer->filterFactory().filter("com.videocore.filters.bgra")));
+            aspectTransform->setOutput(positionTransform);
+            positionTransform->setOutput(m_videoMixer);
+            m_aspectTransform = aspectTransform;
+            m_positionTransform = positionTransform;
 
-        // Inform delegate that camera source has been added
-        if ([_delegate respondsToSelector:@selector(didAddCameraSource:)]) {
-            [_delegate didAddCameraSource:self];
-        }
+            // Inform delegate that camera source has been added
+            if ([_delegate respondsToSelector:@selector(didAddCameraSource:)]) {
+                [_delegate didAddCameraSource:self];
+            }
+        });
     }
     {
         // Add mic source

--- a/sources/iOS/CameraSource.h
+++ b/sources/iOS/CameraSource.h
@@ -64,8 +64,10 @@ namespace videocore { namespace iOS {
          *  \param fps      Optional parameter to set the output frames per second.
          *  \param useFront Start with the front-facing camera
          *  \param useInterfaceOrientation whether to use interface or device orientation as reference for video capture orientation
+         *  \param sessionPreset name of the preset to use for the capture session
+         *  \param callbackBlock block to be called after everything is set
          */
-        void setupCamera(int fps = 15, bool useFront = true, bool useInterfaceOrientation = false, NSString* sessionPreset = nil);
+        void setupCamera(int fps = 15, bool useFront = true, bool useInterfaceOrientation = false, NSString* sessionPreset = nil, void (^callbackBlock)(void) = nil);
 
         
         /*!

--- a/sources/iOS/CameraSource.mm
+++ b/sources/iOS/CameraSource.mm
@@ -103,7 +103,7 @@ namespace videocore { namespace iOS {
     }
     
     void
-    CameraSource::setupCamera(int fps, bool useFront, bool useInterfaceOrientation, NSString* sessionPreset)
+    CameraSource::setupCamera(int fps, bool useFront, bool useInterfaceOrientation, NSString* sessionPreset, void (^callbackBlock)(void))
     {
         m_fps = fps;
         m_useInterfaceOrientation = useInterfaceOrientation;
@@ -185,6 +185,9 @@ namespace videocore { namespace iOS {
                         }
                     }
                     [output release];
+                }
+                if (callbackBlock) {
+                    callbackBlock();
                 }
             }
         };


### PR DESCRIPTION
... the session has started.

This allows being sure that code executed in VCSimpleSession after this method is executed really after the camera and the session have been initialized. This caused problems especially in the first run of an application, because the "pemissions" block is not executed after the user grants the permission to use the camera. In that case, the didAddCameraSource() delegate was called before the camera was available and the calls for setting continuous autofocus and exposure were failing.

These changes should be backwards-compatible since the new parameter is added at the end of the signature of the method and has a nil default value.