### PR TITLE
Add video->bitrate to delegate parameter

### DIFF
--- a/api/iOS/VCSimpleSession.h
+++ b/api/iOS/VCSimpleSession.h
@@ -66,7 +66,7 @@ typedef NS_ENUM(NSInteger, VCAspectMode)
 - (void) connectionStatusChanged: (VCSessionState) sessionState;
 @optional
 - (void) didAddCameraSource:(VCSimpleSession*)session;
-- (void) detectedThroughput: (NSInteger) throughputInBytesPerSecond;
+- (void) detectedThroughput: (NSInteger) throughputInBytesPerSecond videoRate:(NSInteger) rate;
 @end
 
 @interface VCSimpleSession : NSObject

--- a/api/iOS/VCSimpleSession.h
+++ b/api/iOS/VCSimpleSession.h
@@ -66,6 +66,8 @@ typedef NS_ENUM(NSInteger, VCAspectMode)
 - (void) connectionStatusChanged: (VCSessionState) sessionState;
 @optional
 - (void) didAddCameraSource:(VCSimpleSession*)session;
+
+- (void) detectedThroughput: (NSInteger) throughputInBytesPerSecond; //Depreciated, should use method below
 - (void) detectedThroughput: (NSInteger) throughputInBytesPerSecond videoRate:(NSInteger) rate;
 @end
 

--- a/api/iOS/VCSimpleSession.mm
+++ b/api/iOS/VCSimpleSession.mm
@@ -577,9 +577,13 @@ namespace videocore { namespace simpleApi {
                                               auto audio = std::dynamic_pointer_cast<videocore::IEncoder>( bSelf->m_aacEncoder );
                                               if(video && audio && bSelf.useAdaptiveBitrate) {
 
-                                                  if([bSelf.delegate respondsToSelector:@selector(detectedThroughput:videoRate:)]) {
+                                                  if ([bSelf.delegate respondsToSelector:@selector(detectedThroughput:)]) {
+                                                      [bSelf.delegate detectedThroughput:predicted];
+                                                  }
+                                                  if ([bSelf.delegate respondsToSelector:@selector(detectedThroughput:videoRate:)]) {
                                                       [bSelf.delegate detectedThroughput:predicted videoRate:video->bitrate()];
                                                   }
+                                                  
 
                                                   int videoBr = 0;
 

--- a/api/iOS/VCSimpleSession.mm
+++ b/api/iOS/VCSimpleSession.mm
@@ -577,8 +577,8 @@ namespace videocore { namespace simpleApi {
                                               auto audio = std::dynamic_pointer_cast<videocore::IEncoder>( bSelf->m_aacEncoder );
                                               if(video && audio && bSelf.useAdaptiveBitrate) {
 
-                                                  if([bSelf.delegate respondsToSelector:@selector(detectedThroughput:)]) {
-                                                      [bSelf.delegate detectedThroughput:predicted];
+                                                  if([bSelf.delegate respondsToSelector:@selector(detectedThroughput:videoRate:)]) {
+                                                      [bSelf.delegate detectedThroughput:predicted videoRate:video->bitrate()];
                                                   }
 
                                                   int videoBr = 0;


### PR DESCRIPTION
- Add a new parameter to detectedThroughput delegate
- Get the last known actual video rate in the delegate 
- Can better handle video quality in the delegate !