### PR TITLE
Fix ChinanetCenter CDN push crash

### DIFF
--- a/api/iOS/VCSimpleSession.mm
+++ b/api/iOS/VCSimpleSession.mm
@@ -548,11 +548,8 @@ namespace videocore { namespace simpleApi {
                                                               case kClientStateError:
                                                                   bSelf.rtmpSessionState = VCSessionStateError;
                                                                   [bSelf endRtmpSession];
-
-                                                                  if (bSelf && bSelf->m_outputSession) {
-                                                                      bSelf->m_outputSession.reset();
-                                                                  }
                                                                   break;
+
                                                               case kClientStateNotConnected:
                                                                   bSelf.rtmpSessionState = VCSessionStateEnded;
                                                                   [bSelf endRtmpSession];

--- a/api/iOS/VCSimpleSession.mm
+++ b/api/iOS/VCSimpleSession.mm
@@ -523,9 +523,7 @@ namespace videocore { namespace simpleApi {
 {
     std::stringstream uri ;
     uri << (rtmpUrl ? [rtmpUrl UTF8String] : "") << "/" << (streamKey ? [streamKey UTF8String] : "");
-
-    VCSimpleSession* bSelf = self;
-
+    
     m_outputSession.reset(
                           new videocore::RTMPSession ( uri.str(),
                                                       [=](videocore::RTMPSession& session,
@@ -536,23 +534,26 @@ namespace videocore { namespace simpleApi {
                                                           switch(state) {
 
                                                               case kClientStateConnected:
-                                                                  bSelf.rtmpSessionState = VCSessionStateStarting;
+                                                                  self.rtmpSessionState = VCSessionStateStarting;
                                                                   break;
                                                               case kClientStateSessionStarted:
+                                                              {
+
+                                                                  __block VCSimpleSession* bSelf = self;
                                                                   dispatch_async(_graphManagementQueue, ^{
                                                                       [bSelf addEncodersAndPacketizers];
                                                                   });
-                                                                  bSelf.rtmpSessionState = VCSessionStateStarted;
+                                                              }
+                                                                  self.rtmpSessionState = VCSessionStateStarted;
 
                                                                   break;
                                                               case kClientStateError:
-                                                                  bSelf.rtmpSessionState = VCSessionStateError;
-                                                                  [bSelf endRtmpSession];
+                                                                  self.rtmpSessionState = VCSessionStateError;
+                                                                  [self endRtmpSession];
                                                                   break;
-
                                                               case kClientStateNotConnected:
-                                                                  bSelf.rtmpSessionState = VCSessionStateEnded;
-                                                                  [bSelf endRtmpSession];
+                                                                  self.rtmpSessionState = VCSessionStateEnded;
+                                                                  [self endRtmpSession];
                                                                   break;
                                                               default:
                                                                   break;
@@ -560,6 +561,7 @@ namespace videocore { namespace simpleApi {
                                                           }
 
                                                       }) );
+    VCSimpleSession* bSelf = self;
 
     _bpsCeiling = _bitrate;
 
@@ -581,7 +583,7 @@ namespace videocore { namespace simpleApi {
                                                   if ([bSelf.delegate respondsToSelector:@selector(detectedThroughput:videoRate:)]) {
                                                       [bSelf.delegate detectedThroughput:predicted videoRate:video->bitrate()];
                                                   }
-                                                  
+
 
                                                   int videoBr = 0;
 

--- a/rtmp/RTMPSession.cpp
+++ b/rtmp/RTMPSession.cpp
@@ -948,6 +948,11 @@ namespace videocore
                 p += amfPrimitiveObjectSize(p);
                 props[propName] = "";
             }
+            // Fix large AMF object may break to multiple packets
+            // that crash us.
+            if (strcmp(propName, "code") == 0) {
+                break;
+            }
         } while (get_be24(p) != AMF_DATA_TYPE_OBJECT_END);
         
         //p = start;


### PR DESCRIPTION
RTMP block if large as 128 bytes, it should break to two blocks. Our
parse is too navie to handle this and will crash.

That’s happen on ChinanetCenter’s RTMP CDN system.