### PR TITLE
Allow mono or stereo audio

### DIFF
--- a/api/iOS/VCSimpleSession.mm
+++ b/api/iOS/VCSimpleSession.mm
@@ -291,10 +291,10 @@ namespace videocore { namespace simpleApi {
 }
 - (void) setAudioChannelCount:(int)channelCount
 {
-    _audioChannelCount = MIN(2, MAX(channelCount,2)); // We can only support a channel count of 2 with AAC
+    _audioChannelCount = MAX(1, MIN(channelCount, 2));
 
     if(m_audioMixer) {
-        m_audioMixer->setChannelCount(channelCount);
+        m_audioMixer->setChannelCount(_audioChannelCount);
     }
 }
 - (int) audioChannelCount


### PR DESCRIPTION
Hello,

This a change to allow mono audio in outbound RTMP. I saw the comment indicating that AAC only supports stereo, but in my testing it seems that mono works fine.

I would be happy to hear under what circumstances stereo is required, or maybe this has changed in newer iOS SDKs.

This change also fixes a possible bug when passing channelCount to the audio mixer.

Reed