### PR TITLE
Provide unabridged CoreFoundation objects to VTCompressionSessionCreate

### DIFF
--- a/transforms/Apple/H264Encode.mm
+++ b/transforms/Apple/H264Encode.mm
@@ -181,14 +181,18 @@ namespace videocore { namespace Apple {
 #endif
         VTCompressionSessionRef session = nullptr;
         @autoreleasepool {
+            SInt32 cvPixelFormatTypeValue = ::kCVPixelFormatType_32BGRA;
+            SInt8  boolYESValue = 0xFF;
+
+            CFDictionaryRef emptyDict = ::CFDictionaryCreate(kCFAllocatorDefault, nil, nil, 0, nil, nil);
+            CFNumberRef cvPixelFormatType = ::CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, (const void*)(&(cvPixelFormatTypeValue)));
+            CFNumberRef frameW = ::CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, (const void*)(&(m_frameW)));
+            CFNumberRef frameH = ::CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, (const void*)(&(m_frameH)));
+            CFNumberRef boolYES = ::CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt8Type, (const void*)(&(boolYESValue)));
             
-            
-            NSDictionary* pixelBufferOptions = @{ (NSString*) kCVPixelBufferPixelFormatTypeKey : //@(kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange),
-                                                  @(kCVPixelFormatType_32BGRA),
-                                                  (NSString*) kCVPixelBufferWidthKey : @(m_frameW),
-                                                  (NSString*) kCVPixelBufferHeightKey : @(m_frameH),
-                                                  (NSString*) kCVPixelBufferOpenGLESCompatibilityKey : @YES,
-                                                  (NSString*) kCVPixelBufferIOSurfacePropertiesKey : @{}};
+            const void *pixelBufferOptionsDictKeys[] = { kCVPixelBufferPixelFormatTypeKey, kCVPixelBufferWidthKey,  kCVPixelBufferHeightKey, kCVPixelBufferOpenGLESCompatibilityKey, kCVPixelBufferIOSurfacePropertiesKey};
+            const void *pixelBufferOptionsDictValues[] = { cvPixelFormatType,  frameW, frameH, boolYES, emptyDict};
+                CFDictionaryRef pixelBufferOptions = ::CFDictionaryCreate(kCFAllocatorDefault, pixelBufferOptionsDictKeys, pixelBufferOptionsDictValues, 5, nil, nil);
             
             err = VTCompressionSessionCreate(
                                              kCFAllocatorDefault,
@@ -196,11 +200,18 @@ namespace videocore { namespace Apple {
                                              m_frameH,
                                              kCMVideoCodecType_H264,
                                              encoderSpecifications,
-                                             (__bridge CFDictionaryRef)pixelBufferOptions,
+                                             pixelBufferOptions,
                                              NULL,
                                              &vtCallback,
                                              this,
                                              &session);
+            
+            CFRelease(emptyDict);
+            CFRelease(cvPixelFormatType);
+            CFRelease(frameW);
+            CFRelease(frameH);
+            CFRelease(boolYES);
+            CFRelease(pixelBufferOptions);
             
         }
         


### PR DESCRIPTION
- I was not able compile a x86_simulator a with literals and NSxx collection objects present in that class.
- While currently a simulator target does not make sense because it does not have a video source, let's have it compile to this target in case a "file based" CameraSource mockup would  ever be considered (for unit testing, etc)
