### PR TITLE
Bug Fix: Check current queue before calling delegate on main queue

### DIFF
--- a/api/iOS/VCSimpleSession.mm
+++ b/api/iOS/VCSimpleSession.mm
@@ -264,12 +264,18 @@ namespace videocore { namespace simpleApi {
 - (void) setRtmpSessionState:(VCSessionState)rtmpSessionState
 {
     _rtmpSessionState = rtmpSessionState;
-    dispatch_async(dispatch_get_main_queue(), ^{
-        // trigger in main thread, avoid autolayout engine exception
-        if(self.delegate) {
+    if (NSOperationQueue.currentQueue != NSOperationQueue.mainQueue) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            // trigger in main thread, avoid autolayout engine exception
+            if(self.delegate) {
                 [self.delegate connectionStatusChanged:rtmpSessionState];
+            }
+        });
+    } else {
+        if (self.delegate) {
+            [self.delegate connectionStatusChanged:rtmpSessionState];
         }
-    });
+    }
 }
 - (VCSessionState) rtmpSessionState
 {


### PR DESCRIPTION
Bug occurs in dealloc when `[self endRtmpSession]` is called. This method sets `rtmpSessionState` to ended. This particular instance happens to occur on the main thread already. Calling dispatch_async on the main queue from the main queue causes the method to run later in the run loop and can result in crash with exception during deallocation process if containing view controller and `VCSessionDelegate` is being dismissed. 

Fix just checks if we are already on the main queue before dispatching the delegate method call on the main queue. 

Thanks!
