### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ videocore::Apple::StreamSession : videocore::IStreamSession
 * 0.1.2 
 	* Fixes a serious bug in the GenericAudioMixer that was causing 100% cpu usage and audio lag.
 * 0.1.1 
- 	* Fixes Cocoapods namespace conflicts for UriParser-cpp
+ 	* Fixes CocoaPods namespace conflicts for UriParser-cpp
 * 0.1.0 
 	* Initial CocoaPods version
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
