### PR TITLE
Add space for header search paths

### DIFF
--- a/VideoCore.podspec
+++ b/VideoCore.podspec
@@ -35,7 +35,8 @@ Pod::Spec.new do |s|
   s.dependency          'glm', '~> 0.9.4.6'
   s.dependency          'UriParser-cpp', '~> 0.1.3'
 
-  s.xcconfig            = { "HEADER_SEARCH_PATHS" => "${PODS_ROOT}/boost" }
+  s.xcconfig            = { "HEADER_SEARCH_PATHS" => '"${PODS_ROOT}/boost"' + " " +
+						                                         '"${PODS_ROOT}/Headers/Public/glm/**"' }
 
   s.ios.deployment_target = '5.0'
 


### PR DESCRIPTION
We were having a problem with xcode throwing errors when trying to build due to file missing. Added the ${PODS_ROOT}/Headers/Public/glm/** to rectify that issue.